### PR TITLE
Don't echo MFA PIN + token code when entered

### DIFF
--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -571,7 +571,7 @@ class OktaClient(object):
         """ Submit verification code for SMS or TOTP authentication methods"""
         pass_code = self._mfa_code
         if pass_code is None:
-            pass_code = self.ui.input("Enter verification code: ")
+            pass_code = self.ui.input("Enter verification code: ", hidden=True)
         response = self._http_client.post(
             next_url,
             params={'rememberDevice': self._remember_device},

--- a/gimme_aws_creds/ui.py
+++ b/gimme_aws_creds/ui.py
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and* limitations under the License.*
 """
 import builtins
+import getpass
 import os
 import sys
 
@@ -42,7 +43,7 @@ class UserInterface:
         """
         raise NotImplementedError()
 
-    def read_input(self):
+    def read_input(self, hidden=False):
         """returns user input
         :rtype: str
         """
@@ -54,13 +55,13 @@ class UserInterface:
         """
         raise NotImplementedError()
 
-    def input(self, message=None):
+    def input(self, message=None, hidden=False):
         """handles asking for user input, calls prompt() then read_input()
         :type message: str
         :rtype: str
         """
         self.prompt(message)
-        return self.read_input()
+        return self.read_input(hidden)
 
     def info(self, message):
         """handles messages meant for info
@@ -102,16 +103,16 @@ class CLIUserInterface(UserInterface):
     def prompt(self, message=None):
         if message is not None:
             builtins.print(message, file=sys.stderr, end='')
+            sys.stderr.flush()
 
     def message(self, message):
         builtins.print(message, file=sys.stderr)
 
-    def read_input(self):
-        return builtins.input()
+    def read_input(self, hidden=False):
+        return getpass.getpass('') if hidden else builtins.input()
 
     def notify(self, message):
         builtins.print(message, file=sys.stderr)
-
 
 cli = CLIUserInterface()
 default = cli

--- a/tests/test_okta_client.py
+++ b/tests/test_okta_client.py
@@ -515,7 +515,8 @@ class TestOktaClient(unittest.TestCase):
 
     @responses.activate
     @patch('builtins.input', return_value='12345678')
-    def test_login_input_mfa_challenge(self, mock_input):
+    @patch('getpass.getpass', return_value='1234qwert')
+    def test_login_input_mfa_challenge(self, mock_input, mock_pass):
         """Test that MFA works with Okta"""
 
         verify_response = {

--- a/tests/test_okta_client.py
+++ b/tests/test_okta_client.py
@@ -514,9 +514,8 @@ class TestOktaClient(unittest.TestCase):
         assert_equals(result, {'stateToken': self.state_token, 'apiResponse': verify_response})
 
     @responses.activate
-    @patch('builtins.input', return_value='12345678')
     @patch('getpass.getpass', return_value='1234qwert')
-    def test_login_input_mfa_challenge(self, mock_input, mock_pass):
+    def test_login_input_mfa_challenge(self, mock_pass):
         """Test that MFA works with Okta"""
 
         verify_response = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added optional parameter `hidden` to UserInterface.input() requesting that the input not be echoed as it is entered; the prompt for MFA in okta.py now passes `hidden=True`. The implementation in CLIUserInterface uses `getpass.getpass()` instead of `builtins.input()` if `hidden` is set. Since `getpass` is insistent about getting its prompt output, `prompt` in the same implementation also has to flush stderr to ensure that its prompt is output before getpass asks for input.

## Related Issue
https://github.com/Nike-Inc/gimme-aws-creds/issues/225

## Motivation and Context
The required response string for certain MFA setups (notably RSA) includes a secret component (the user's PIN) that should never be displayed.

## How Has This Been Tested?
Manually imported ui, instantiated CLIUserInterface(), and prompted for input both with and without messages and hidden=True
Installed module from git clone and configured and ran to get MFA prompt, confirmed it didn't echo
Modified relevant test to mock getpass.getpass instead of builtins.input so it passes without interruption.

## Screenshots (if appropriate):

## Types of changes:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
